### PR TITLE
Neue Funktion Weckruf und Status-Weckruf 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Folgende Funktionen stehen momentan zur Verfügung:
         WakeOnLan [Name des LAN Geraetes] - Beispiel: FritzBox.sh WakeOnLan Geraetename   
         DECT [0|1]    Schaltet DECT ein bzw. aus 
         UMTS [0|1]    Schaltet UMTS ein bzw. aus 
-<<<<<<< HEAD
         NACHTRUHE [0|1]   Schaltet Nachruhe ein bzw. aus 
         KLINGELSPERRE [0|1]    Schaltet KLINGELSPERRE ein bzw. aus
         ANRUFEN [(Telefonnummer z.B. **610)]   Ruf diese Nummer über das Telefon an  
@@ -84,18 +83,6 @@ Folgende Funktionen stehen momentan zur Verfügung:
         AB [0|1|2...-9] [0|1] - Beispiel schaltet den 2. AB ein: FritzBox.sh AB 1 1
         Anrufliste     Erstellt eine Anrufliste fuer Webmatic
         Anrufliste2CCU [0000(HOMEMATIC Webmatic SYSVAR ID)] [Anzahl Eintraege]    Erstellt eine Anrufliste in eine CCU-Variable
-=======
-        NACHTRUHE [0|1]   Schaltet Nachruhe ein bzw. aus  
-        KLINGELSPERRE [0|1]    Schaltet KLINGELSPERRE ein bzw. aus  
-        ANRUFEN [(Telefonnummer z.B. **610)]   Ruf diese Nummer über das Telefon an  
-        RUFUMLEITUNG [0|1|2|3(Rufumleistung)] [0|1]   Konfiguriert eine Rufumleitung  
-        Diversity [0|1|2|3(Rufumleistung)] [0|1]     Konfiguriert eine Rufumleitung 
-        DECT200 [16|17|18|19] [0|1]     Schaltet DECT200 Geraete ein bzw. aus  
-        DECT200Energie [Nummer des Aktors:16|17|18|19] [Name der Variable in der CCU] - Beispiel: FritzBox.sh DECT200Energie 16 DECT200     
-        AB [0|1|2...-9] [0|1] - Beispiel schaltet den 2. AB ein: FritzBox.sh AB 1 1  
-        Anrufliste     Erstellt eine Anrufliste fuer Webmatic  
-        Anrufliste2CCU [0000(HOMEMATIC Webmatic SYSVAR ID)] [Anzahl Eintraege]    Erstellt eine Anrufliste in eine CCU-Variable  
->>>>>>> origin/pr/8
         Status-Rufumleitung [Name der logischen Variable (Bool)in der CCU] Beispiel: FritzBox.sh Status-Rufumleitung RufumleitungVariableCCU 
         Status-DECT [Name der logischen Variable (Bool)in der CCU] Beispiel: FritzBox.sh Status-DECT DECTanausVariableCCU 
         Status-DECT200 [16|17|18|19] [Name der logischen Variable (Bool)in der CCU] Beispiel: FritzBox.sh Status-DECT200 16 DECT16VariableCCU  
@@ -105,12 +92,5 @@ Folgende Funktionen stehen momentan zur Verfügung:
         Status-Verbindungszeit [Name der logischen Variable (Zeichenkette)in der CCU] Beispiel: FritzBox.sh Status-Verbindungszeit InternetVerbindungszeitVariableCCU 
         Status-WLAN [Name der logischen Variable (Bool)in der CCU] Beispiel: FritzBox.sh Status-WLAN WLANanausVariableCCU 
         Status-WLANGast [Name der logischen Variable (Bool)in der CCU] Beispiel: FritzBox.sh SStatus-WLANGast WLANGastanausVariableCCU 
-<<<<<<< HEAD
         Status-WLANZeitschaltung  [Name der logischen Variable (Bool)in der CCU] Beispiel: FritzBox.sh Status-WLANZeitschaltung WLANZeitschaltungVariableCCU 
         reboot    Startet die Fritzbox neu
-=======
-        Status-WLANZeitschaltung  [Name der logischen Variable (Bool)in der CCU] Beispiel: FritzBox.sh Status-WLANZeitschaltung WLANZeitschaltungVariableCCU  
-        Weckruf [0|1|2] [0|1] - Beispiel: Schaltet den ersten Weckruf ein  FritzBox.sh Weckruf 0 1  
-		Status-Weckruf [0|1|2] [Name der logischen Variable (Bool)in der CCU] - Beispiel: FritzBox.sh Status-Weckruf 0 CCUvarWeckruf1  		
-        reboot    Startet die Fritzbox neu  
->>>>>>> origin/pr/8


### PR DESCRIPTION
Weckruf [0|1|2] [0|1] - Beispiel: Schaltet den ersten Weckruf ein
FritzBox.sh Weckruf 0 1
Status-Weckruf [0|1|2] [Name der logischen Variable (Bool)in der CCU] -
Beispiel: FritzBox.sh Status-Weckruf 0 CCUvarWeckruf1
+Bugfixes
